### PR TITLE
Split MinIO into a dedicated DevPods pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ curl -fsSL https://raw.githubusercontent.com/mrmeaow/devpods/main/devpods.sh | b
 | `dev-seq-pod`   | Seq                                     | Ingest + UI → `5341`       | [Guide](./docs/seq.md)      |
 | `dev-rmq-pod`   | RabbitMQ 3 (management)                 | AMQP `5672` · UI → `15672` | [Guide](./docs/rabbitmq.md) |
 | `dev-nats-pod`  | NATS 2 + JetStream                      | `4222` · Monitor → `8222`  | [Guide](./docs/nats.md)     |
+| `dev-sms-pod`   | devsms                                  | `4000` · `5153`            | [Guide](./docs/devsms.md)   |
+| `dev-minio-pod` | MinIO                                   | `9000` · `9001`            | [Guide](./docs/minio.md)    |
 
 All persistent data lives in **`~/.devpods/<pod-name>/`** — fully isolated from your project.
 
@@ -78,6 +80,8 @@ mail / mailpit     → dev-mail-pod
 seq                → dev-seq-pod
 rmq / rabbitmq     → dev-rmq-pod
 nats               → dev-nats-pod
+sms / devsms      → dev-sms-pod
+minio             → dev-minio-pod
 all                → every pod above
 ```
 
@@ -117,6 +121,11 @@ RMQ Mgmt     http://localhost:15672  (devuser / devpass)
 
 NATS         nats://localhost:4222
 NATS Monitor  http://localhost:8222
+
+devsms API   http://localhost:4000
+devsms UI    http://localhost:5153
+MinIO API    http://localhost:9000
+MinIO Console http://localhost:9001
 ```
 
 ---
@@ -136,6 +145,9 @@ RMQ_PASS=devpass
 MONGO_RS=rs0
 ME_USER=admin
 ME_PASS=admin
+MINIO_ROOT_USER=devminio
+MINIO_ROOT_PASS=devminio123
+MINIO_BUCKET=devsms
 ```
 
 Edit that file to override anything. It is **never** committed — it lives only on your machine.
@@ -192,6 +204,12 @@ podman exec -it dev-mongo-pod-mongodb mongosh --eval "rs.status()"
 
 # Inspect all pods
 podman pod ps
+
+# MinIO health
+curl -I http://localhost:9000/minio/health/live
+
+# devsms logs
+podman logs -f dev-sms-pod-devsms
 ```
 
 ---

--- a/docs/devsms.md
+++ b/docs/devsms.md
@@ -1,0 +1,20 @@
+# 📮 devsms Guide
+
+DevPods provides a dedicated `dev-sms-pod` that runs:
+
+- **devsms API** on [http://localhost:4000](http://localhost:4000)
+- **devsms UI** on [http://localhost:5153](http://localhost:5153)
+
+## Start only this pod
+
+```bash
+bash devpods.sh up sms
+```
+
+## Useful checks
+
+```bash
+# Tail devsms logs
+podman logs -f dev-sms-pod-devsms
+
+```

--- a/docs/minio.md
+++ b/docs/minio.md
@@ -1,0 +1,32 @@
+# 🪣 MinIO Guide
+
+DevPods provides a dedicated `dev-minio-pod` that runs:
+
+- **MinIO API** on [http://localhost:9000](http://localhost:9000)
+- **MinIO Console** on [http://localhost:9001](http://localhost:9001)
+
+## Start only this pod
+
+```bash
+bash devpods.sh up minio
+```
+
+## Default credentials
+
+From `~/.devpods/.env`:
+
+```bash
+MINIO_ROOT_USER=devminio
+MINIO_ROOT_PASS=devminio123
+MINIO_BUCKET=devsms
+```
+
+## Useful checks
+
+```bash
+# MinIO liveness endpoint
+curl -I http://localhost:9000/minio/health/live
+
+# Tail MinIO logs
+podman logs -f dev-minio-pod-minio
+```


### PR DESCRIPTION
### Motivation
- Address feedback that MinIO should not be colocated inside the SMS pod and instead run as its own single-purpose pod for clearer separation of concerns and independent lifecycle. 
- Keep `dev-sms-pod` focused on running only the `devsms` app with its correct ports and runtime defaults.

### Description
- Introduced a new `dev-minio-pod` with ports `9000:9000` and `9001:9001`, added alias `minio`, and added it to `ALL_PODS` and `POD_PORTS`. 
- Refactored `_up_sms` to launch only `ghcr.io/mrmeaow/devsms:latest` and added `_up_minio` to launch `docker.io/minio/minio:latest` with persistent data and credential wiring via `_load_env` defaults. 
- Updated pod launch routing (`_launch_pod`), status endpoints, cheatsheet generation (`_summary`), `~/.devpods/.env` sample defaults, and usage/help text to reflect separate `dev-sms-pod` and `dev-minio-pod`. 
- Added documentation files `docs/devsms.md` and `docs/minio.md` and updated `README.md` to list the two distinct pods and their endpoints. 

### Testing
- Ran a static syntax check `bash -n devpods.sh`, which completed successfully. 
- Ran the automated E2E suite via `npm test` (Vitest), which exercised tests but the MongoDB Replica Set E2E timed out in this environment due to lack of a local Mongo replica set, so the failing tests are environmental and not related to the MinIO/SMS split.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb3b2863083339ce90f5ae91c4d2e)